### PR TITLE
Dashboard layout for mobile and desktop

### DIFF
--- a/src/app/dashboard/(dashboard)/MobileHeader.test.tsx
+++ b/src/app/dashboard/(dashboard)/MobileHeader.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import MobileHeader from './MobileHeader';
+import { useState as useStateMock } from 'react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useState: jest.fn(),
+}));
+(useStateMock as jest.Mock).mockImplementation((init) => [init, jest.fn()]);
+
+describe('MobileHeader component', () => {
+  const [showPanel, setShowPanel] = useStateMock(false);
+  it('should render', () => {
+    render(<MobileHeader showPanel={showPanel} setShowPanel={setShowPanel} />);
+
+    const header = screen.getByTestId('mobile-header');
+
+    expect(header).toBeInTheDocument();
+  });
+});
+
+describe('MobileHeader show panel button', () => {
+  const [showPanel, setShowPanel] = useStateMock(false);
+  it('should render', async () => {
+    const user = userEvent.setup();
+    render(<MobileHeader showPanel={showPanel} setShowPanel={setShowPanel} />);
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    expect(setShowPanel).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/app/dashboard/(dashboard)/MobileHeader.tsx
+++ b/src/app/dashboard/(dashboard)/MobileHeader.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Menu, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import React from 'react';
+import { cn } from '@/lib/utils';
+import useWindowInnerWidth from '@/lib/hooks/useWindowInnerWidth';
+
+const MobileHeader = ({
+  showPanel,
+  setShowPanel,
+}: {
+  showPanel: boolean;
+  setShowPanel: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+  const windowInnerWidth = useWindowInnerWidth();
+
+  return (
+    <div
+      data-testid='mobile-header'
+      className={cn(
+        'tw-sticky tw-top-0 tw-w-full tw-h-16 tw-py-2 tw-px-3 tw-flex tw-justify-between tw-items-center tw-bg-white tw-border-b tw-border-neutral-400',
+        windowInnerWidth > 768 && 'tw-hidden'
+      )}
+    >
+      <h3>nexticket</h3>
+      <Button
+        variant='ghost'
+        onClick={() => setShowPanel(!showPanel)}
+        className='hover:tw-bg-transparent'
+      >
+        {showPanel ? <X /> : <Menu />}
+      </Button>
+    </div>
+  );
+};
+
+export default MobileHeader;

--- a/src/app/dashboard/(dashboard)/Navigation.tsx
+++ b/src/app/dashboard/(dashboard)/Navigation.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Home, Ticket, User } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import MobileHeader from './MobileHeader';
+import NavigationPanel from './NavigationPanel';
+
+export interface ILink {
+  label: string;
+  href: string;
+  icon?: React.ReactElement;
+}
+
+const links: ILink[] = [
+  {
+    label: 'Dashboard',
+    href: '/dashboard',
+    icon: <Home size={20} aria-label='Home link icon' />,
+  },
+  {
+    label: 'Tickets',
+    href: '/dashboard/tickets',
+    icon: <Ticket size={20} aria-label='Ticket link icon' />,
+  },
+  {
+    label: 'Users',
+    href: '/dashboard/users',
+    icon: <User size={20} aria-label='User link icon' />,
+  },
+];
+
+const Navigation = () => {
+  const [showPanel, setShowPanel] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      if (window.innerWidth > 768) {
+        setShowPanel(true);
+      }
+    }
+    window.addEventListener('resize', () => {
+      if (window.innerWidth > 768) {
+        setShowPanel(true);
+      } else {
+        setShowPanel(false);
+      }
+    });
+  }, []);
+
+  return (
+    <>
+      <MobileHeader showPanel={showPanel} setShowPanel={setShowPanel} />
+      <NavigationPanel showPanel={showPanel} links={links} />
+    </>
+  );
+};
+
+export default Navigation;

--- a/src/app/dashboard/(dashboard)/NavigationPanel.test.tsx
+++ b/src/app/dashboard/(dashboard)/NavigationPanel.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { ILink } from './Navigation';
+import NavigationPanel from './NavigationPanel';
+import { useState as useStateMock } from 'react';
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useState: jest.fn(),
+}));
+(useStateMock as jest.Mock).mockImplementation((init) => [init, jest.fn()]);
+
+describe('NavigationPanel component', () => {
+  it('renders', () => {
+    const [showPanel] = useStateMock(true);
+    render(<NavigationPanel showPanel={showPanel} links={[]} />);
+
+    const navigationPanel = screen.getByTestId('navigation-panel');
+
+    expect(navigationPanel).toBeInTheDocument();
+  });
+});
+
+describe('NavigationPanel navigation links', () => {
+  it('renders navigation links when links prop is provided', () => {
+    const [showPanel] = useStateMock(true);
+    const links: ILink[] = [
+      {
+        label: 'Test link 1',
+        href: '/dashboard',
+      },
+      {
+        label: 'Test link 2',
+        href: '/dashboard',
+      },
+    ];
+    render(<NavigationPanel showPanel={showPanel} links={links} />);
+
+    const navigationLinks = screen.getAllByRole('link');
+
+    expect(navigationLinks).toHaveLength(2);
+  });
+
+  it('does not render navigation links when links prop is not provided', () => {
+    const [showPanel] = useStateMock(true);
+    render(<NavigationPanel showPanel={showPanel} links={[]} />);
+
+    const navigationLinks = screen.queryAllByRole('link');
+
+    expect(navigationLinks).toHaveLength(0);
+  });
+});

--- a/src/app/dashboard/(dashboard)/NavigationPanel.tsx
+++ b/src/app/dashboard/(dashboard)/NavigationPanel.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { ILink } from './Navigation';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { usePathname } from 'next/navigation';
+import useWindowInnerWidth from '@/lib/hooks/useWindowInnerWidth';
+
+const NavigationPanel = ({
+  showPanel,
+  links = [],
+}: {
+  showPanel: boolean;
+  links: ILink[];
+}) => {
+  const pathname = usePathname();
+  const windowInnerWidth = useWindowInnerWidth();
+
+  return (
+    <>
+      <div
+        data-testid='navigation-panel'
+        className={cn(
+          'tw-flex tw-flex-col tw-items-center md:tw-items-start tw-fixed md:tw-static tw-bottom-0 tw-z-50 tw-rounded-[0.75rem_0.75rem_0_0] md:tw-rounded-none tw-py-4 tw-px-6 tw-w-full md:tw-w-52 tw-h-40 md:tw-min-h-screen tw-transition-transform md:tw-transition-none tw-duration-300 tw-shadow-lg tw-shadow-black md:tw-shadow-none md:tw-border-r md:tw-border-black'
+        )}
+        style={{ transform: showPanel ? 'translateY(0)' : 'translateY(100%)' }}
+      >
+        {windowInnerWidth > 768 ? (
+          <h3 className='tw-self-center'>nexticket</h3>
+        ) : (
+          <div className='tw-bg-gray-300 tw-h-1 tw-w-32 tw-mb-1 tw-rounded-xl'></div>
+        )}
+        <nav className='tw-w-full md:tw-mt-4'>
+          {links.map((link) => (
+            <Link
+              key={link.label}
+              href={link.href}
+              className={cn(
+                'tw-py-2 md:tw-py-3  tw-w-full tw-flex tw-items-center tw-justify-end md:tw-justify-start tw-gap-3',
+                pathname === link.href && 'tw-font-bold tw-pointer-events-none'
+              )}
+            >
+              {windowInnerWidth > 768 ? (
+                <>
+                  {link.icon}
+                  {link.label}
+                </>
+              ) : (
+                <>
+                  {link.label}
+                  {link.icon}
+                </>
+              )}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </>
+  );
+};
+
+export default NavigationPanel;

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,5 +1,6 @@
 import AccessExpired from '@/components/shared/AccessExpired';
 import { Metadata } from 'next';
+import Navigation from './(dashboard)/Navigation';
 import React from 'react';
 import { getUserAccount } from './actions';
 
@@ -9,7 +10,6 @@ export const metadata: Metadata = {
 
 const AppLayout = async ({ children }: { children: React.ReactElement }) => {
   const getUserAccountResponse = await getUserAccount();
-  console.log(getUserAccountResponse);
 
   return (
     <AccessExpired
@@ -19,7 +19,12 @@ const AppLayout = async ({ children }: { children: React.ReactElement }) => {
         getUserAccountResponse.data.statusCode === 401
       }
     >
-      <main>{children}</main>
+      <main className='md:tw-grid tw-grid-cols-[auto_1fr]'>
+        <Navigation />
+        <div className='tw-min-h-[calc(100vh-4rem)] tw-py-2 md:tw-py-4 tw-px-3 md:tw-px-6'>
+          {children}
+        </div>
+      </main>
     </AccessExpired>
   );
 };

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,8 +1,8 @@
 const Dashboard = async () => {
   return (
-    <div>
-      <h1>Dashboard</h1>
-    </div>
+    <>
+      <p>Dashboard</p>
+    </>
   );
 };
 

--- a/src/app/dashboard/tickets/page.tsx
+++ b/src/app/dashboard/tickets/page.tsx
@@ -1,0 +1,9 @@
+const Tickets = () => {
+  return (
+    <>
+      <p>Tickets</p>
+    </>
+  );
+};
+
+export default Tickets;

--- a/src/app/dashboard/users/page.tsx
+++ b/src/app/dashboard/users/page.tsx
@@ -1,0 +1,9 @@
+const Users = () => {
+  return (
+    <>
+      <p>Users</p>
+    </>
+  );
+};
+
+export default Users;

--- a/src/lib/hooks/useWindowInnerWidth.tsx
+++ b/src/lib/hooks/useWindowInnerWidth.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const useWindowInnerWidth = () => {
+  const [windowInnerWidth, setWindowInnerWidth] = useState<number>(0);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setWindowInnerWidth(window.innerWidth);
+      window.addEventListener('resize', () => {
+        setWindowInnerWidth(window.innerWidth);
+      });
+    }
+  }, []);
+
+  return windowInnerWidth;
+};
+
+export default useWindowInnerWidth;


### PR DESCRIPTION
# Added
- Hook to get window's inner width.
- Header component for mobile layout.
- Responsive navigation panel (needs testing on larger screen).