### PR TITLE
Revalidate user account after register organization

### DIFF
--- a/src/app/dashboard/register-organization/actions.tsx
+++ b/src/app/dashboard/register-organization/actions.tsx
@@ -1,16 +1,20 @@
 'use server';
 
 import fetchNexticket from '@/lib/customFetch';
+import { revalidateTag } from 'next/cache';
 
 export const registerOrganization = async (
   name: string,
   email_domain: string
 ) => {
-  return await fetchNexticket('/organization', {
+  const response = await fetchNexticket('/organization', {
     method: 'POST',
     body: { name, email_domain },
     options: {
       cache: 'no-store',
     },
   });
+
+  if (response.ok) revalidateTag('user-account');
+  return response;
 };


### PR DESCRIPTION
# Fixed
- Successful organization registration should now invalidate user-account cache and trigger a re-fetch.